### PR TITLE
feat: add logo next to site title

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,10 @@ All visualizations are rendered on Canvas (Chart.js), with no SVG or Mermaid JS 
     <header class="bg-white/90 backdrop-blur-md sticky top-0 z-50 shadow-sm border-b border-[var(--color-border)]">
         <nav class="container mx-auto px-4">
             <div class="flex items-center justify-between h-16">
-                <h1 class="text-lg font-bold text-[var(--color-primary)] truncate">Voz y Dignidad Indígena</h1>
+                <div class="flex items-center space-x-2">
+                    <img src="CNMI.png" alt="CNMI logo" class="h-8 w-8 object-contain">
+                    <h1 class="text-lg font-bold text-[var(--color-primary)] truncate">Voz y Dignidad Indígena</h1>
+                </div>
                 <div class="hidden md:flex items-center space-x-4">
                     <a href="#panorama" class="px-3 py-2 rounded-md text-sm font-medium border-b-2">Panorama</a>
                     <a href="#autonomias" class="px-3 py-2 rounded-md text-sm font-medium border-b-2">Autonomías</a>


### PR DESCRIPTION
## Summary
- display CNMI logo alongside main header title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ba5c0a9dac832c91688a843ede3dba